### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     }
   },
   "require": {
-    "slim/slim": "^3.0@RC",
     "pimple/pimple": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.0"
+    "phpunit/phpunit": "^5.0",
+    "slim/slim": "3.0.0-RC3"
   }
 }

--- a/tests/SlimPimpleBridgeTest.php
+++ b/tests/SlimPimpleBridgeTest.php
@@ -3,8 +3,8 @@
 namespace Geggleto\Test;
 
 use Geggleto\SlimPimpleBridge;
-use Slim\Container as SlimContainer;
 use Pimple\Container as PimpleContainer;
+use Slim\Container as SlimContainer;
 
 class SlimPimpleBridgeTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Because `slim/slim` is only required for unit tests.
