### PR TITLE
Refactor bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     }
   },
   "require": {
-    "pimple/pimple": "^3.0"
+    "pimple/pimple": "^3.0",
+    "slim/slim": "3.0.0-RC3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.0",
-    "slim/slim": "3.0.0-RC3"
+    "phpunit/phpunit": "^5.0"
   }
 }

--- a/src/SlimPimpleBridge.php
+++ b/src/SlimPimpleBridge.php
@@ -9,28 +9,48 @@ namespace Geggleto;
 
 use Pimple\Container as PimpleContainer;
 use Pimple\ServiceProviderInterface;
+use Slim\Container as SlimContainer;
 
 final class SlimPimpleBridge implements ServiceProviderInterface
 {
     /**
-     * Public constructor.
-     *
-     * @param PimpleContainer $container Your existing Pimple container
+     * @var PimpleContainer
      */
-    public function __construct(PimpleContainer $container)
+    private $pimpleContainer;
+
+    /**
+     * Private constructor.
+     *
+     * @param PimpleContainer $pimpleContainer
+     */
+    private function __construct(PimpleContainer $pimpleContainer)
     {
-        $this->container = $container;
+        $this->pimpleContainer = $pimpleContainer;
     }
 
     /**
-     * {@inheritdoc}
+     * Merge a Pimple\Container with a Slim\Container.
      *
-     * @see http://pimple.sensiolabs.org/#extending-a-container
+     * @param SlimContainer   $slimContainer
+     * @param PimpleContainer $pimpleContainer
+     *
+     * @return SlimContainer The original $slimContainer, which now includes
+     *                       all of the services from the $pimpleContainer
      */
-    public function register(PimpleContainer $pimple)
+    public static function merge(SlimContainer $slimContainer, PimpleContainer $pimpleContainer)
     {
-        foreach ($this->container->keys() as $key) {
-            $pimple[$key] = $this->container->raw($key);
+        $slimContainer->register(new self($pimpleContainer));
+
+        return $slimContainer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function register(PimpleContainer $slimContainer)
+    {
+        foreach ($this->pimpleContainer->keys() as $key) {
+            $slimContainer[$key] = $this->pimpleContainer->raw($key);
         }
     }
 }

--- a/tests/SlimPimpleBridgeTest.php
+++ b/tests/SlimPimpleBridgeTest.php
@@ -11,19 +11,23 @@ class SlimPimpleBridgeTest extends \PHPUnit_Framework_TestCase
     public function testSlimPimpleBridge()
     {
         // Represents an existing container that needs to be integrated into
-        // the Slim\Container
+        // a Slim\Container
         $myExistingPimpleContainer = new PimpleContainer();
+        // Define some services
         $myExistingPimpleContainer['test'] = function ($c) {
             return 'TEST';
         };
 
-        $bridge = new SlimPimpleBridge($myExistingPimpleContainer);
-
         $slimContainer = new SlimContainer();
 
-        // Uses the SlimPimpleBridge to add existing services to the SlimContainer
-        $slimContainer->register($bridge);
+        // Now merge the two containers!
+        $container = SlimPimpleBridge::merge(
+            $slimContainer,
+            $myExistingPimpleContainer
+        );
 
-        $this->assertEquals('TEST', $slimContainer->get('test'));
+        $this->assertSame($slimContainer, $container);
+        $this->assertInstanceOf('Slim\Handlers\Error', $container->get('errorHandler'));
+        $this->assertEquals('TEST', $container->get('test'));
     }
 }


### PR DESCRIPTION
Existing bridge wasn't quite specific enough, IMO. Being a simple Pimple
ServiceProvider without typehinting against the `Slim\Container` felt
broken somehow. This new implementation forces the use of the
`SlimPimpleBridge::merge()` method to merge a `Pimple\Container` into a
`Slim\Container`, uses the correct type hints, and hides the previous
`Pimple\ServiceProviderInterface` implementation behind a private constructor. I
_think_ I've accomplished limiting the use of the slim-pimple-bridge library to
the specific use-case intended: Merging an existing `Pimple\Container`
into a `Slim\Container` to allow use of the original services within the
context of a Slim 3 application.
